### PR TITLE
[codex] Fix linked card preview state

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -17,6 +17,57 @@
   document.addEventListener("DOMContentLoaded", function () {
     var themeToggle = document.querySelector("[data-theme-toggle]");
     var lastPreviewTrigger = null;
+    var shouldRestorePreviewFocus = false;
+    var cardLinkSelector = ".news-card--link, .update-card--link, .showcase-card";
+    var cardFocusResetKey = "jackie-reset-card-focus";
+
+    function rememberCardFocusReset() {
+      try {
+        sessionStorage.setItem(cardFocusResetKey, "1");
+      } catch (error) {}
+    }
+
+    function clearRestoredCardFocus() {
+      var shouldClear = false;
+
+      try {
+        shouldClear = sessionStorage.getItem(cardFocusResetKey) === "1";
+      } catch (error) {}
+
+      if (!shouldClear) return;
+
+      if (
+        document.activeElement &&
+        typeof document.activeElement.matches === "function" &&
+        document.activeElement.matches(cardLinkSelector)
+      ) {
+        document.activeElement.blur();
+      }
+
+      try {
+        sessionStorage.removeItem(cardFocusResetKey);
+      } catch (error) {}
+    }
+
+    window.addEventListener("pageshow", function () {
+      window.requestAnimationFrame(clearRestoredCardFocus);
+    });
+
+    document.addEventListener("visibilitychange", function () {
+      if (document.visibilityState !== "visible") return;
+      window.requestAnimationFrame(clearRestoredCardFocus);
+    });
+
+    document.querySelectorAll(cardLinkSelector).forEach(function (link) {
+      link.addEventListener("click", function (event) {
+        if (event.defaultPrevented) return;
+        if (event.button !== 0) return;
+        if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+
+        rememberCardFocusReset();
+      });
+    });
+
     if (themeToggle) {
       themeToggle.addEventListener("click", function () {
         var isLight = document.documentElement.classList.toggle("theme-light");
@@ -112,12 +163,12 @@
     }
 
     var previewDialog = document.querySelector("[data-preview-dialog]");
-    var previewFrame = document.querySelector("[data-preview-frame]");
-    var previewTitle = document.querySelector("[data-preview-title]");
-    var previewSummary = document.querySelector("[data-preview-summary]");
-    var previewOrigin = document.querySelector("[data-preview-origin]");
-    var previewFallback = document.querySelector("[data-preview-fallback]");
-    var previewSourceLink = document.querySelector("[data-preview-open-source]");
+    var previewFrame = previewDialog ? previewDialog.querySelector("[data-preview-frame]") : null;
+    var previewTitle = previewDialog ? previewDialog.querySelector("[data-preview-title]") : null;
+    var previewSummary = previewDialog ? previewDialog.querySelector("[data-preview-summary]") : null;
+    var previewOrigin = previewDialog ? previewDialog.querySelector("[data-preview-origin]") : null;
+    var previewFallback = previewDialog ? previewDialog.querySelector("[data-preview-fallback]") : null;
+    var previewSourceLink = previewDialog ? previewDialog.querySelector("[data-preview-open-source]") : null;
     var previewCloseButton = previewDialog ? previewDialog.querySelector(".preview-modal__close") : null;
 
     function closePreviewDialog() {
@@ -133,8 +184,11 @@
       }
 
       if (lastPreviewTrigger) {
-        lastPreviewTrigger.focus();
+        if (shouldRestorePreviewFocus) {
+          lastPreviewTrigger.focus();
+        }
         lastPreviewTrigger = null;
+        shouldRestorePreviewFocus = false;
       }
     }
 
@@ -191,6 +245,7 @@
 
         event.preventDefault();
         lastPreviewTrigger = link;
+        shouldRestorePreviewFocus = event.detail === 0;
         openPreviewDialog(link);
       });
     });

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -551,6 +551,34 @@ html.theme-light .detail-card {
   color: inherit;
 }
 
+.preview-card,
+.preview-card:visited,
+.preview-card:hover,
+.preview-card:focus,
+.preview-card:focus-visible,
+.showcase-card,
+.showcase-card:visited,
+.showcase-card:hover,
+.showcase-card:focus,
+.showcase-card:focus-visible,
+.update-card--link,
+.update-card--link:visited,
+.update-card--link:hover,
+.update-card--link:focus,
+.update-card--link:focus-visible,
+.news-card--link,
+.news-card--link:visited,
+.news-card--link:hover,
+.news-card--link:focus,
+.news-card--link:focus-visible {
+  color: inherit;
+}
+
+.update-card h3,
+.news-card h2 {
+  color: var(--text-primary);
+}
+
 .preview-grid,
 .showcase-grid {
   display: grid;


### PR DESCRIPTION
## What changed
- keep linked card UI stable across visited, hover, and focus states
- scope preview-modal DOM queries to the modal container so clicking a card no longer rewrites the card content itself
- only restore focus to the preview trigger for keyboard-opened dialogs, and clear restored card focus on page return

## Why
Linked cards were visually breaking after interaction. In the `news` and `update` flows, the preview-modal script queried `[data-preview-title]` and `[data-preview-summary]` at the document level, which matched the card trigger attributes instead of the modal fields and replaced the card DOM with summary text. Separately, card links were still exposed to global visited/focus behavior, which made return states inconsistent.

## Impact
- linked cards on the news page keep their label, title, and summary after opening and closing previews
- homepage update cards inherit the same fix because they use the same preview logic
- linked card appearance is more stable after returning to a page or closing a preview dialog

## Root cause
The preview dialog code used unscoped selectors for modal fields, so card trigger elements were mutated in place. Global link visited/focus behavior also leaked into card components that expected fixed visual styling.

## Validation
- `bundle exec jekyll build`
- local Playwright verification of the `Ignite Launch` card before and after opening/closing the preview dialog